### PR TITLE
feat: sway inventory support

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -268,18 +268,19 @@ _ps.gui = flow.make_gui(function(player,ctx)
         svbox.name = "svbox"
         settings_screen = gui.ScrollableVBox(svbox)
     end
-    local rtn_gui = gui.VBox {
+    local content_body = gui.HBox {
+        gui.ScrollableVBox(navbar),
+        settings_screen
+    }
+    local content_with_header = gui.VBox {
         gui.HBox {
             gui.Label { label = S("Settings"), expand = true, align_h = "left" },
             gui.ButtonExit { w = 0.7, h = 0.7, label = "x" }
         },
         gui.Box{w = 1, h = 0.05, color = "grey", padding = 0},
-        gui.HBox {
-            gui.ScrollableVBox(navbar),
-            settings_screen
-        }
+        content_body
     }
-    return rtn_gui
+    return ctx.inside_sway and content_body or content_with_header
 end)
 
 minetest.register_chatcommand("settings", {
@@ -288,3 +289,20 @@ minetest.register_chatcommand("settings", {
         _ps.gui:show(minetest.get_player_by_name(name))
     end
 })
+
+if minetest.get_modpath("sway") then
+    sway.register_page("player_settings:settings", {
+        title = S("Settings"),
+        get = function (_self, player, ctx)
+            if not ctx.player_settings then
+                ctx.player_settings = { inside_sway = true }
+            end
+            return sway.Form {
+                _ps.gui:embed {
+                    player = player,
+                    name = "player_settings"
+                }
+            }
+        end
+    })
+end

--- a/mod.conf
+++ b/mod.conf
@@ -2,3 +2,4 @@ name = player_settings
 title = Player Settings
 description = Player-specific settings
 depends = flow
+optional_depends = sway


### PR DESCRIPTION
requires current version of flow

closes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Restructured GUI layout for improved organization.
	- ~~Dynamic return logic enhances user context adaptation.~~ to clarify the blibber blabbing, the AI means to say that depending on if the form is embedded in sway, certain widgits, like the close button are not rendered.
	- ~~Added chat command for accessing settings page.~~ - this was already present. The AI hallucinated. I did, however, add a new page to sway.

- **Chores**
	- ~~Introduced optional dependency for `player_settings` in the configuration, enhancing module flexibility.~~ another hallucination. I added an optional dependency on `sway`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->